### PR TITLE
Fixing issue in VML when container is set

### DIFF
--- a/js/1.3.12/jsPlumb-renderers-vml-1.3.12-RC1.js
+++ b/js/1.3.12/jsPlumb-renderers-vml-1.3.12-RC1.js
@@ -94,7 +94,11 @@
 	_node = function(name, d, atts, parent, _jsPlumb) {
 		atts = atts || {};
 		var o = document.createElement("jsplumb:" + name);				
-		_jsPlumb.appendElement(o, parent);
+		if(parent){
+		  _jsPlumb.CurrentLibrary.appendElement(o, parent);
+		} else {	
+		  _jsPlumb.appendElement(o, parent);
+		}
 		o.className = (atts["class"] ? atts["class"] + " " : "") + "jsplumb_vml";
 		_pos(o, d);
 		_atts(o, atts);


### PR DESCRIPTION
Fixed issue where all VML elements are added directly to the container instead of being nested inside the container div elements if the container is set.
