### PR TITLE
Prevent overriding defaults in setConnector.

### DIFF
--- a/js/1.4.0/jsPlumb-1.4.0-RC1.js
+++ b/js/1.4.0/jsPlumb-1.4.0-RC1.js
@@ -4418,7 +4418,7 @@ between this method and jsPlumb.reset).
 					if (connector.length == 1)
 						this.connector = makeConnector(renderMode, connector[0], connectorArgs);
 					else
-						this.connector = makeConnector(renderMode, connector[0], jsPlumbUtil.merge(connector[1], connectorArgs));
+						this.connector = makeConnector(renderMode, connector[0], jsPlumbUtil.merge(jsPlumbUtil.clone(connector[1]), connectorArgs));
 				}
 				self.canvas = self.connector.canvas;
 				// binds mouse listeners to the current connector.


### PR DESCRIPTION
For connector types with additional arguments (like 'flowchart') the setConnector method may accidentally extend the global defaults.
