### PR TITLE
Updated doWhileSuspended to revert suspendDrawing to it's previous status rather than force it off.

### DIFF
--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -2768,6 +2768,7 @@
         // suspends drawing, runs the given function, then re-enables drawing (and repaints,
         // unless you tell it not to)
         this.doWhileSuspended = function(fn, doNotRepaintAfterwards) {
+			var wasDrawingSuspended = _currentInstance.isSuspendDrawing();
 			_currentInstance.setSuspendDrawing(true);
 			try {
 				fn();
@@ -2775,7 +2776,7 @@
 			catch (e) {
 				_log("Function run while suspended failed", e);
 			}
-			_currentInstance.setSuspendDrawing(false, !doNotRepaintAfterwards);
+			_currentInstance.setSuspendDrawing(wasDrawingSuspended, !doNotRepaintAfterwards);
         };
             
         this.updateOffset = _updateOffset;


### PR DESCRIPTION
Fix for performance issue https://github.com/sporritt/jsPlumb/issues/49

With our usage of jsPlumb I haven't detected any issues caused by this (and there is a significant speedup), however it does alter aspects of library's behaviour, notably if someone was relying on doWhileSuspended to switch off isSuspendDrawing that will no longer work.
Also various internal calls use doWhileSuspended so they can't be used to switch off isSuspendDrawing  either.
