### PR TITLE
Fix "beforeDrop" issue with multiple jsPlumb instances

### DIFF
--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -2073,8 +2073,8 @@
 				_targetEndpointDefinitions[elid] = p;
 				_targetEndpointsUnique[elid] = p.uniqueEndpoint,
 				_targetMaxConnections[elid] = maxConnections,
-				_targetsEnabled[elid] = true,
-				proxyComponent = new jsPlumbUIComponent(p);								
+				_targetsEnabled[elid] = true;
+				var proxyComponent = new jsPlumbUIComponent(p);								
 				
 				var dropOptions = jsPlumb.extend({}, p.dropOptions || {}),
 				_drop = function() {


### PR DESCRIPTION
When using multiple jsPlumb instances and makeTarget() together, the "beforeDrop" event is always triggered on the last created jsPlumb instance, not necessarily the correct one.

This patch fixes the issue for me.
