### PR TITLE
SVG renderer's gradient referred to document.location.toString() + #hash...

### DIFF
--- a/src/renderers-svg.js
+++ b/src/renderers-svg.js
@@ -111,7 +111,7 @@
 		var applyGradientTo = style.strokeStyle ? STROKE : FILL;
         //document.location.toString()
 		//node.setAttribute(STYLE, applyGradientTo + ":url(#" + id + ")");
-        node.setAttribute(STYLE, applyGradientTo + ":url(" + document.location.toString() + "#" + id + ")");
+        node.setAttribute(STYLE, applyGradientTo + ":url(#" + id + ")");
 	},
 	_applyStyles = function(parent, node, style, dimensions, uiComponent) {
 		


### PR DESCRIPTION
..., which broke gradients in pages that already contains a hash

See: http://jsplumbtoolkit.com/demo/sourcesAndTargets/jquery.html#foo

Remove the hash from the URL, and the demo works again.

The :url() seems to work without the full URL, just the #gradient_id is needed. Might need some research, I only tested with Chrome.

Cheers!
