### PR TITLE
Added missing return in addClass when handling an SVGAnimatedString

### DIFF
--- a/src/dom.jsPlumb.js
+++ b/src/dom.jsPlumb.js
@@ -116,7 +116,8 @@
 			el = jsPlumb.CurrentLibrary.getElementObject(el);
 			try {
 				if (el[0].className.constructor == SVGAnimatedString) {
-					jsPlumbUtil.svg.addClass(el[0], clazz);                    
+					jsPlumbUtil.svg.addClass(el[0], clazz);     
+					return;
 				}
 			}
 			catch (e) {


### PR DESCRIPTION
In dom.jsPlumb.js, added a missing "return;" statement after line 119.

Line 119 correctly handles the SVGAnimatedString special case.

Without the added return, execution continues to line 126 which should only handle the default cases.
