### PR TITLE
bugfix for overlay positions on blank endpoints

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1011,7 +1011,10 @@
 		this.type = "Blank";
 		DOMElementEndpoint.apply(this, arguments);		
 		this._compute = function(anchorPoint, orientation, endpointStyle, connectorPaintStyle) {
-			return [anchorPoint[0], anchorPoint[1],10,0];
+			// changed last two array elements from "..,10,0]" to ",1,1]" so is has 
+			// a height for an overlay to calculate its position from, made it 1,1
+			// instead of 10,10 to be pixel precise
+			return [anchorPoint[0], anchorPoint[1],1,1];
 		};
 		
 		this.canvas = document.createElement("div");


### PR DESCRIPTION
Seems to have been a bug with the overlay position for blank endpoints. Since the last array element was 0, the y-position of the overlay for this endpoint was multiplied with 0 and therefore didn't change. Changed the last two array elements to 1,1 instead of 10,0 so the positioning of overlays on blank endpoints is now pixel precise.
