### PR TITLE
1.6-beta does not return originalEvent in connectionDragStop

### DIFF
--- a/src/dom.jsPlumb.js
+++ b/src/dom.jsPlumb.js
@@ -143,7 +143,7 @@
 		getDragScope : function(el) {
 			return el._katavorioDrag && el._katavorioDrag.scopes.join(" ") || "";
 		},
-		getDropEvent : function(args) { return args[0].event; },
+		getDropEvent : function(args) { return args[0].event || args[0].e; },
 		getDropScope : function(el) {
 			return el._katavorioDrop && el._katavorioDrop.scopes.join(" ") || "";
 		},


### PR DESCRIPTION
The argument has an 'e' attribute, not an 'event' attribute, so it
returned undefined.

This is broken for the connectionDragStop event, I'm not sure if this is
called from multiple places. With this fix both ways still work.
