### PR TITLE
Removes document.location.toString() from uri for the SVG gradient

### DIFF
--- a/src/renderers-svg.js
+++ b/src/renderers-svg.js
@@ -111,7 +111,7 @@
 		var applyGradientTo = style.strokeStyle ? STROKE : FILL;
         //document.location.toString()
 		//node.setAttribute(STYLE, applyGradientTo + ":url(#" + id + ")");
-        node.setAttribute(STYLE, applyGradientTo + ":url(" + document.location.toString() + "#" + id + ")");
+        node.setAttribute(STYLE, applyGradientTo + ":url(#" + id + ")");
 	},
 	_applyStyles = function(parent, node, style, dimensions, uiComponent) {
 		


### PR DESCRIPTION
Patch looks reasonable. Possibly, line 113 should simply be reactivated and line 114 deleted.
