### PR TITLE
updateOffsets() might encounter a stale reference

### DIFF
--- a/src/dom-adapter.js
+++ b/src/dom-adapter.js
@@ -97,6 +97,7 @@
 				children = _delements[id],
 				parentOffset = jpcl.getOffset(el);
 				
+				var inv_zoom = 1/_currentInstance.getZoom();
 			if (children) {
 				for (var i in children) {
 					var cel = jpcl.getElementObject(i);
@@ -111,8 +112,8 @@
                         _delements[id][i] = {
                             id:i,
                             offset:{
-                                left:cOff.left - parentOffset.left,
-                                top:cOff.top - parentOffset.top
+                                left: (cOff.left - parentOffset.left) * inv_zoom, //need to remove zoom because these offsets will have zoom applied later
+                                top: (cOff.top - parentOffset.top) * inv_zoom
                             }
                         };
                         _draggablesForElements[i] = id;

--- a/src/dom-adapter.js
+++ b/src/dom-adapter.js
@@ -99,17 +99,24 @@
 				
 			if (children) {
 				for (var i in children) {
-					var cel = jpcl.getElementObject(i),
-						cOff = jpcl.getOffset(cel);
+					var cel = jpcl.getElementObject(i);
 						
-					_delements[id][i] = {
-						id:i,
-						offset:{
-							left:cOff.left - parentOffset.left,
-							top:cOff.top - parentOffset.top
-						}
-					};
-					_draggablesForElements[i] = id;
+					// need to check if cel is available, it might've been deleted
+					// if it's deleted, we want to update the internal reference
+					if (cel.length == 0) {	
+                        delete _delements[id][i];
+                        delete _draggablesForElements[i];
+                    } else {
+                        var cOff = jpcl.getOffset(cel);
+                        _delements[id][i] = {
+                            id:i,
+                            offset:{
+                                left:cOff.left - parentOffset.left,
+                                top:cOff.top - parentOffset.top
+                            }
+                        };
+                        _draggablesForElements[i] = id;
+                    }
 				}
 			}
 		};


### PR DESCRIPTION
Since updateOffsets() iterates through a list of hash objects that contain id and offset, it's potentially trying to retrieve an endPoint html object that's been deleted. I've updated updateOffsets to check if that's the case, and if so, remove the reference in _delements and _draggablesForElements.

A little background: I encountered this issue when I called on unmakeTarget()/unmakeSource() on an element as well as removing it from the DOM which caused adjacent endPoints to be shifted so I had to call on updateOffsets(). 
