### PR TITLE
Fixed #261: create connection to one endpoint on drop

### DIFF
--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -878,7 +878,7 @@
                                 // have a beforeDrop condition (although, secretly, under the hood all Endpoints and 
                                 // the Connection have them, because they are on jsPlumbUIComponent.  shhh!), because
                                 // it only makes sense to have it on a target endpoint.
-                                _doContinue = _doContinue && this.isDropAllowed(jpc.sourceId, jpc.targetId, jpc.scope, jpc, this);
+                                _doContinue = _doContinue && this.isDropAllowed(jpc.sourceId, jpc.targetId, jpc.scope, jpc, this) && jpc.pending;
                                                                                                                     
                                 if (_doContinue) {
                                     continueFunction();


### PR DESCRIPTION
When dropping a new connection insersecting two endpoints, the connection is always visible on the second one, but internally two connections will be created. By adding " && jpc.pending" we ensure that we only create one new connection to the first endpoint.
