### PR TITLE
allow setting a function as a drag filter

### DIFF
--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -2519,7 +2519,7 @@
 	                // lastly, if a filter was provided, set it as a dragFilter on the element,
 	                // to prevent the element drag function from kicking in when we want to
 	                // drag a new connection
-	                if (p.filter && jsPlumbUtil.isString(p.filter)) {
+	                if (p.filter && (jsPlumbUtil.isString(p.filter) || jsPlumbUtil.isFunction(p.filter))) {
 	                	_currentInstance.setDragFilter(_el, p.filter);
 	                }
 				}.bind(this);


### PR DESCRIPTION
This updates jsPlumb to be aware that katavorio can accept functions as filters (and so depends on the similar katavorio pull request).
