### PR TITLE
Fix for using library inside shadowDom (e.g. Polymer etc.)

### DIFF
--- a/src/dom-adapter.js
+++ b/src/dom-adapter.js
@@ -164,7 +164,9 @@
 
 			_elementsWithEndpoints[id] = _elementsWithEndpoints[id] ? _elementsWithEndpoints[id] + 1 : 1;
 
-			while (p != null && p != b) {
+			
+			// if p.host is present p is a shadow dom element, otherwise regular element
+			while (p != null && p != b && p.host===undefined) {
 				var pid = _currentInstance.getId(p, null, true);
 				if (pid && _draggables[pid]) {
 					var pLoc = jsPlumbAdapter.getOffset(p, _currentInstance);


### PR DESCRIPTION
Checks to see if parent element is shadow root. If it is shadowDOM stops going up the DOM tree
without this change endpointAdded goes up the DOM tree and gets to the shadowDOM and causing this error:

<pre>
Uncaught TypeError: undefined is not a function dom.jsPlumb-1.7.2.js:2655
window.jsPlumbAdapter.getAttribute dom.jsPlumb-1.7.2.js:2655
(anonymous function) dom.jsPlumb-1.7.2.js:2064
_getId dom.jsPlumb-1.7.2.js:4039
endpointAdded dom.jsPlumb-1.7.2.js:2463
_newEndpoint dom.jsPlumb-1.7.2.js:3916
addEndpoint dom.jsPlumb-1.7.2.js:4101
</pre>


Not sure if checking for host attribute is universally correct but solved my problem.
