### PR TITLE
Initial setZoom not working due to lazy DragManager initialisation (h…

### DIFF
--- a/src/dom.jsPlumb.js
+++ b/src/dom.jsPlumb.js
@@ -59,6 +59,7 @@
                     ghostProxy:"jtk-ghost-proxy"
                 }
             });
+            k.setZoom(instance.getZoom());
             instance[key] = k;
             instance.bind("zoom", k.setZoom);
         }


### PR DESCRIPTION
Issue: https://github.com/jsplumb/jsPlumb/issues/622

Katavorio now respect current zoom level when initialising