### PR TITLE
Include type definition file in distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "test": "tests"
   },
   "files": [
+    "index.d.ts",
     "dist/js/jsplumb.js",
     "dist/js/jsplumb.min.js",
     "dist/css/jsplumbtoolkit-defaults.css"
   ],
+  "types": "index",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "init":"node ./install.js"


### PR DESCRIPTION
Ordinarily having an `index.d.ts` is enough for distribution; however, in this case it wasn't. I believe it is because the `"files"` property is used, so I've included the definition there. I've also added the `"types"` property for good measure.