### PR TITLE
Fixes ts typedefinition file to fix build time errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ type UUID = string;
 type ElementId = string;
 type ElementRef = ElementId | Element;
 type ElementGroupRef = ElementId | Element | Array<ElementId> | Array<Element>;
-type Endpoint = Object;
 
 // TODO improve this
 type EndpointParams = Object;
@@ -40,7 +39,7 @@ interface jsPlumbInstance {
     getContainer(): Element;
     getDefaultScope(): string;
     getEndpoint(uuid: string): Endpoint;
-    getInstance(_defaults?: Object): void;
+    getInstance(_defaults?: Object): any;
     getScope(Element: Element | string): string;
     getSelector(context?: Element | Selector, spec?: string): void;
     getSourceScope(Element: Element | string): string;


### PR DESCRIPTION
- Removes duplicate definition for `Endpoint`
- Modifies return type of `getInstance` to be `any` for now.

In reference to https://github.com/jsplumb/jsplumb/issues/695