### PR TITLE
Correctly apply cssClass to connectors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -390,7 +390,7 @@
         prepareConnector:function(connectorSpec, typeId) {
             var connectorArgs = {
                     _jsPlumb: this._jsPlumb.instance,
-                    cssClass: (this._jsPlumb.params.cssClass || ""),
+                    cssClass: this._jsPlumb.params.cssClass,
                     container: this._jsPlumb.params.container,
                     "pointer-events": this._jsPlumb.params["pointer-events"]
                 },


### PR DESCRIPTION
cssClass is ignored when we do something like `jsPlumb.addEndpoint(id, { anchors: ["Top"], ["Flowchart", {cssClass: "connector"}], endpoint: "Rectangle"} )` because the default value of connectorArgs is an empty string by default (I think it should be undefined)