### PR TITLE
Calculating parentOffset in dom-adapter.js only when needed

### DIFF
--- a/src/dom-adapter.js
+++ b/src/dom-adapter.js
@@ -55,7 +55,7 @@
          */
         this.register = function (el) {
             var id = _currentInstance.getId(el),
-                parentOffset = _currentInstance.getOffset(el);
+                parentOffset;
 
             if (!_draggables[id]) {
                 _draggables[id] = el;
@@ -71,6 +71,9 @@
                             var cEl = jsPlumb.getElement(p.childNodes[i]),
                                 cid = _currentInstance.getId(p.childNodes[i], null, true);
                             if (cid && _elementsWithEndpoints[cid] && _elementsWithEndpoints[cid] > 0) {
+                                if (!parentOffset) {
+                                    parentOffset = _currentInstance.getOffset(el);
+                                }
                                 var cOff = _currentInstance.getOffset(cEl);
                                 _delements[id][cid] = {
                                     id: cid,
@@ -97,7 +100,7 @@
                 var domEl = jsPlumb.getElement(elId),
                     id = _currentInstance.getId(domEl),
                     children = _delements[id],
-                    parentOffset = _currentInstance.getOffset(domEl);
+                    parentOffset;
 
                 if (children) {
                     for (var i in children) {
@@ -108,6 +111,10 @@
                             // do not update if we have a value already and we'd just be writing 0,0
                             if (cel.offsetParent == null && _delements[id][i] != null) {
                                 continue;
+                            }
+
+                            if (!parentOffset) {
+                                parentOffset = _currentInstance.getOffset(domEl);
                             }
 
                             _delements[id][i] = {


### PR DESCRIPTION
 In dom-adapter.js, parentOffset was getting calculated even if it was not needed under some scenarios. This was causing unnecessary layout thrashing. To avoid it, parentOffset is now calculated only when it is needed.