### PR TITLE
fix jsPlumbInstance.reset

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare module jsPlumb {
 
         repaintEverything(clearEdits?: boolean/* =false */): jsPlumbInstance;
 
-        reset(): void;
+        reset(doNotUnbindInstanceEventListeners?: boolean): void;
 
         restoreDefaults(): jsPlumbInstance;
 


### PR DESCRIPTION
As the parameter type has been absent from definition file, one is forced to use `// @ts-ignore`:

    // @ts-ignore
    jsPlumbInstance.reset(true);