### PR TITLE
Add missing connector property to ConnectorParams object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -273,7 +273,7 @@ declare module jsPlumb {
         anchor?: AnchorSpec;
         anchors?: [AnchorSpec, AnchorSpec];
         label?: string;
-        connector?: string;
+        connector?: ConnectorSpec;
         overlays?:Array<OverlaySpec>;
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,6 +273,7 @@ declare module jsPlumb {
         anchor?: AnchorSpec;
         anchors?: [AnchorSpec, AnchorSpec];
         label?: string;
+        connector?: string;
         overlays?:Array<OverlaySpec>;
     }
 


### PR DESCRIPTION
Add connector property inside ConnectorParams object to specify the connection.