### PR TITLE
Add missing cssClass property for ConnectParams type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,7 @@ declare module jsPlumb {
         label?: string;
         connector?: ConnectorSpec;
         overlays?:Array<OverlaySpec>;
+        cssClass?: string
     }
 
     interface DragEventCallbackOptions {


### PR DESCRIPTION
Add a missing cssClass property for ConnectParams type.

interface ConnectParams {
        uuids?: [UUID, UUID];
        source?: ElementRef | Endpoint;
        target?: ElementRef | Endpoint;
        detachable?: boolean;
        deleteEndpointsOnDetach?: boolean;
        endpoint?: EndpointSpec;
        anchor?: AnchorSpec;
        anchors?: [AnchorSpec, AnchorSpec];
        label?: string;
        connector?: ConnectorSpec;
        overlays?:Array<OverlaySpec>;
        **cssClass: string** 
    }

@sporritt  can you please review the change?