### PR TITLE
Fixed Connection definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -314,6 +314,10 @@ declare module jsPlumb {
         setLabel(s: string): void;
         getElement(): Connection;
         repaint():void;
+        source: Element;
+        target: Element;
+        sourceId: string;
+        targetId: string;
     }
 
 


### PR DESCRIPTION
According to [documentation](https://community.jsplumbtoolkit.com/apidocs/classes/Connection.html#properties), Connection has `source`, `target`, `sourceId`, `targetId`, but they aren't defined in the interface.