### PR TITLE
Added missed declarations for `removeOverlay` and `addOverlay` methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -312,6 +312,8 @@ declare module jsPlumb {
         getLabelOverlay(): Overlay;
         getOverlays(): Object;
         getOverlay(s: string): Overlay;
+        removeOverlay(string: string): void;
+        addOverlay(spec: OverlaySpec): Overlay;
         showOverlay(s: string): void;
         hideOverlay(s: string): void;
         setLabel(s: string): void;


### PR DESCRIPTION
According to documentation ([adding](https://docs.jsplumbtoolkit.com/community/current/articles/overlays.html#adding), [removing](https://docs.jsplumbtoolkit.com/community/current/articles/overlays.html#removing)), Connection has `addOverlay` and `removeOverlay` methods, but they aren't declared in the interface.