### PR TITLE
Update jsplumb.bundle.js

### DIFF
--- a/bundle/dist/jsplumb.bundle.js
+++ b/bundle/dist/jsplumb.bundle.js
@@ -14919,6 +14919,9 @@ var jsPlumbBrowserUI = (function (exports) {
     }, {
       key: "setConnectorHover",
       value: function setConnectorHover(connector, hover, doNotCascade) {
+
+        if (connector.connection.instance._instanceIndex != this._instanceIndex) { return; }
+
         if (hover === false || !this.currentlyDragging && !this.isHoverSuspended()) {
           var canvas = connector.canvas;
           if (canvas != null) {


### PR DESCRIPTION
When there are nested containers rendered on UI (each with a separate JsPlumb instance), the Hover event throws and error.