### PR TITLE
change `src` from `node_modues` to `node_modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The single import for 6.x is:
 If you're not using a package manager at all then you can use the UMD that ships in the jsPlumb package.
 
 ```html
-<script src="node_modues/@jsplumb/browser-ui/js/jsplumb-browser-ui.umd.js"></script>
+<script src="node_modules/@jsplumb/browser-ui/js/jsplumb-browser-ui.umd.js"></script>
 ```
 
 ---


### PR DESCRIPTION
[Update README.md change `src` from `node_modues` to `node_modules` in <script> tag](https://github.com/jsplumb/jsplumb/commit/0887d065b5c67489c43f024a06706b899ff00321)